### PR TITLE
Recalculate topLeft after window resized

### DIFF
--- a/packages/tailwind-inspect/src/views/App.tsx
+++ b/packages/tailwind-inspect/src/views/App.tsx
@@ -125,6 +125,16 @@ const SelectionOverlay = observer(function SelectionOverlay({
       setTopLeft(new Vec2(left, top));
     }
   }, []);
+  useEffect(( ) => {
+    const handler = () => {
+      if (ref.current) {
+        const { top, left } = ref.current.getBoundingClientRect();
+        setTopLeft(new Vec2(left, top));
+      }
+    }
+    window.addEventListener('resize', handler)
+    return () => window.removeEventListener('change', handler)
+  })
 
   return (
     <svg


### PR DESCRIPTION
Seems this need to be fixed by observing resizing event. Current implementation (x, y) coords are wrongly calculated.